### PR TITLE
Support provide ComposeComponentExtras

### DIFF
--- a/compose/koject-compose-core/src/commonMain/kotlin/com/moriatsushi/koject/compose/RememberInject.kt
+++ b/compose/koject-compose-core/src/commonMain/kotlin/com/moriatsushi/koject/compose/RememberInject.kt
@@ -2,12 +2,16 @@ package com.moriatsushi.koject.compose
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
 import com.moriatsushi.koject.ExperimentalKojectApi
 import com.moriatsushi.koject.Named
 import com.moriatsushi.koject.Qualifier
 import com.moriatsushi.koject.component.Component
 import com.moriatsushi.koject.component.ComponentExtras
 import com.moriatsushi.koject.inject
+
+@OptIn(ExperimentalKojectApi::class)
+val LocalComposeComponentExtras = staticCompositionLocalOf<ComponentExtras<*>?> { null }
 
 /**
  * Inject an instance with resolved dependencies
@@ -21,20 +25,16 @@ import com.moriatsushi.koject.inject
  * }
  * ```
  *
- * @param qualifier Qualifier for identification.
- *   Specify the instantiation of the annotation with [Qualifier].
+ * @param componentExtras Specify [ComponentExtras] to create [Component].
  */
 @OptIn(ExperimentalKojectApi::class)
 @Composable
 inline fun <reified T : Any> rememberInject(
-    qualifier: Any? = null,
+    componentExtras: ComponentExtras<*>? = LocalComposeComponentExtras.current,
 ): T {
-    val componentExtras = composeComponentExtras()
-    return remember(qualifier) {
-        inject(
-            qualifier = qualifier,
-            componentExtras = componentExtras,
-        )
+    val finalComponentExtras = componentExtras ?: composeComponentExtras()
+    return remember {
+        inject(componentExtras = finalComponentExtras)
     }
 }
 
@@ -57,11 +57,12 @@ inline fun <reified T : Any> rememberInject(
 @ExperimentalKojectApi
 @Composable
 inline fun <reified T : Any> rememberInject(
-    qualifier: Any? = null,
-    componentExtras: ComponentExtras<*>?,
+    qualifier: Any?,
+    componentExtras: ComponentExtras<*>? = LocalComposeComponentExtras.current,
 ): T {
+    val finalComponentExtras = componentExtras ?: composeComponentExtras()
     return remember(qualifier) {
-        inject(qualifier, componentExtras)
+        inject(qualifier, finalComponentExtras)
     }
 }
 
@@ -103,9 +104,10 @@ inline fun <reified T : Any> rememberInject(
 @Composable
 inline fun <reified T : Any> rememberInject(
     name: String,
-    componentExtras: ComponentExtras<*>? = null,
+    componentExtras: ComponentExtras<*>? = LocalComposeComponentExtras.current,
 ): T {
+    val finalComponentExtras = componentExtras ?: composeComponentExtras()
     return remember(name) {
-        inject(name, componentExtras)
+        inject(name, finalComponentExtras)
     }
 }

--- a/integration-test/compose/src/androidMain/kotlin/com/moriatsushi/koject/integrationtest/compose/CustomComposeComponent.kt
+++ b/integration-test/compose/src/androidMain/kotlin/com/moriatsushi/koject/integrationtest/compose/CustomComposeComponent.kt
@@ -1,0 +1,38 @@
+package com.moriatsushi.koject.integrationtest.compose
+
+import android.content.Context
+import com.moriatsushi.koject.ExperimentalKojectApi
+import com.moriatsushi.koject.Provides
+import com.moriatsushi.koject.component.Component
+import com.moriatsushi.koject.component.ComponentExtras
+import com.moriatsushi.koject.compose.ComposeContext
+import com.moriatsushi.koject.compose.ComposeCoroutineScope
+import kotlinx.coroutines.CoroutineScope
+
+@Component
+@MustBeDocumented
+@Retention(AnnotationRetention.BINARY)
+annotation class CustomComposeComponent
+
+@OptIn(ExperimentalKojectApi::class)
+internal class CustomComposeComponentExtras(
+    @ComposeContext
+    val context: Context,
+    @ComposeCoroutineScope
+    val coroutineScope: CoroutineScope,
+) : ComponentExtras<CustomComposeComponent>
+
+@CustomComposeComponent
+@Provides
+class ForCustomComposeWithContext(
+    val applicationContext: Context,
+    @ComposeContext
+    val composeContext: Context,
+)
+
+@CustomComposeComponent
+@Provides
+class ForCustomComposeWithContext2(
+    @ComposeCoroutineScope
+    val coroutineScope: CoroutineScope,
+)

--- a/integration-test/compose/src/androidUnitTest/kotlin/com/moriatsushi/koject/integrationtest/compose/AndroidComposeComponentTest.kt
+++ b/integration-test/compose/src/androidUnitTest/kotlin/com/moriatsushi/koject/integrationtest/compose/AndroidComposeComponentTest.kt
@@ -1,10 +1,14 @@
 package com.moriatsushi.koject.integrationtest.compose
 
 import android.app.Application
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.moriatsushi.koject.Koject
+import com.moriatsushi.koject.compose.LocalComposeComponentExtras
 import com.moriatsushi.koject.compose.rememberInject
 import kotlin.test.assertEquals
 import org.junit.Rule
@@ -25,6 +29,31 @@ class AndroidComposeComponentTest {
             val value: ForComposeWithContext = rememberInject()
             assertEquals(localContext, value.composeContext)
             assertEquals(applicationContext, value.applicationContext)
+        }
+    }
+
+    @Test
+    fun inject_customComposeComponent() = Koject.runTest {
+        composeTestRule.setContent {
+            val localContext = LocalContext.current
+            val coroutineScope = rememberCoroutineScope()
+            val extras = remember {
+                CustomComposeComponentExtras(
+                    context = localContext,
+                    coroutineScope = coroutineScope,
+                )
+            }
+
+            val value: ForCustomComposeWithContext = rememberInject(extras)
+            assertEquals(localContext, value.composeContext)
+            assertEquals(applicationContext, value.applicationContext)
+
+            CompositionLocalProvider(
+                LocalComposeComponentExtras provides extras,
+            ) {
+                val value2: ForCustomComposeWithContext2 = rememberInject()
+                assertEquals(coroutineScope, value2.coroutineScope)
+            }
         }
     }
 }


### PR DESCRIPTION
Default `ComposeComponentExtras` function is too little, I added `LocalComposeComponentExtras` for customization. 

By the way. what about move default `ComposeComponentExtras` out of the `compose-core` library to omit this part of the compilation.